### PR TITLE
Fix error when puuid gathered is "BOT"

### DIFF
--- a/services/match_history/service.py
+++ b/services/match_history/service.py
@@ -94,7 +94,7 @@ class Platform:
                                 WHERE puuid IN (
                                     SELECT puuid
                                     FROM summoner
-                                    WHERE last_platform = any($1::platform[])
+                                    WHERE last_platform = any($1::platform[]) AND puuid <> 'BOT'
                                     ORDER BY CASE WHEN last_updated IS NULL THEN 0 ELSE 1 END, last_updated
                                     LIMIT $2
                                     FOR UPDATE


### PR DESCRIPTION
Fix 'BOT' user beeing added to match-history queue and causing Non200Exception.
![image](https://github.com/DoctressWasTaken/Lightshield/assets/35538496/d0df5507-a441-4817-a44d-13f3fe748cc1)
